### PR TITLE
Add per-hole par input and display

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,12 +17,14 @@ def index():
 @app.route('/add_tour', methods=['GET', 'POST'])
 def add_tour():
     if request.method == 'POST':
+        pars = [request.form.get(f'par_{i}', type=int) for i in range(1, 19)]
         tour = {
             'name': request.form.get('name'),
             'golf': request.form.get('golf'),
             'par': request.form.get('par'),
             'slope': request.form.get('slope'),
             'sss': request.form.get('sss'),
+            'pars': pars,
         }
         tours_table.insert(tour)
         return redirect(url_for('index'))
@@ -49,6 +51,8 @@ def add_score(tour_id):
         }
         scores_table.insert(score)
         return redirect(url_for('index'))
+    if 'pars' not in tour:
+        tour['pars'] = [4] * 18
     return render_template('add_score.html', tour=tour)
 
 if __name__ == '__main__':

--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -18,6 +18,7 @@
             <thead>
                 <tr>
                     <th>Trou</th>
+                    <th>Par</th>
                     <th>Coups</th>
                     <th>Fairway</th>
                     <th>Green en régulation</th>
@@ -29,6 +30,7 @@
                 {% for i in range(1, 19) %}
                 <tr>
                     <td>{{ i }}</td>
+                    <td>{{ tour.pars[i-1] }}</td>
                     <td><input type="number" name="strokes_{{ i }}" required></td>
                     <td><input type="checkbox" name="fairway_{{ i }}"></td>
                     <td><input type="checkbox" name="gir_{{ i }}"></td>

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -19,6 +19,23 @@
         <label>Par du parcours <input type="number" name="par" required></label><br>
         <label>Slope <input type="number" name="slope" required></label><br>
         <label>SSS <input type="number" name="sss" required></label><br>
+        <h2>Par par trou</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Trou</th>
+                    <th>Par</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for i in range(1, 19) %}
+                <tr>
+                    <td>{{ i }}</td>
+                    <td><input type="number" name="par_{{ i }}" required></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
         <button type="submit">Enregistrer</button>
     </form>
 </main>


### PR DESCRIPTION
## Summary
- include per-hole par fields when adding a tour
- show par values on the Add Score page
- store par list in TinyDB and fall back to par 4s if missing

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851865533588332b2b78c5ada36bef1