### PR TITLE
Fix integer input handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,9 +21,9 @@ def add_tour():
         tour = {
             'name': request.form.get('name'),
             'golf': request.form.get('golf'),
-            'par': request.form.get('par'),
-            'slope': request.form.get('slope'),
-            'sss': request.form.get('sss'),
+            'par': request.form.get('par', type=int),
+            'slope': request.form.get('slope', type=int),
+            'sss': request.form.get('sss', type=int),
             'pars': pars,
         }
         tours_table.insert(tour)

--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -31,11 +31,11 @@
                 <tr>
                     <td>{{ i }}</td>
                     <td>{{ tour.pars[i-1] }}</td>
-                    <td><input type="number" name="strokes_{{ i }}" required></td>
+                    <td><input type="number" name="strokes_{{ i }}" step="1" required></td>
                     <td><input type="checkbox" name="fairway_{{ i }}"></td>
                     <td><input type="checkbox" name="gir_{{ i }}"></td>
-                    <td><input type="number" name="putts_{{ i }}" required></td>
-                    <td><input type="number" name="given_{{ i }}" required></td>
+                    <td><input type="number" name="putts_{{ i }}" step="1" required></td>
+                    <td><input type="number" name="given_{{ i }}" step="1" required></td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -16,9 +16,9 @@
     <form method="post">
         <label>Nom du Tour <input type="text" name="name" required></label><br>
         <label>Golf joué <input type="text" name="golf" required></label><br>
-        <label>Par du parcours <input type="number" name="par" required></label><br>
-        <label>Slope <input type="number" name="slope" required></label><br>
-        <label>SSS <input type="number" name="sss" required></label><br>
+        <label>Par du parcours <input type="number" name="par" step="1" required></label><br>
+        <label>Slope <input type="number" name="slope" step="1" required></label><br>
+        <label>SSS <input type="number" name="sss" step="1" required></label><br>
         <h2>Par par trou</h2>
         <table>
             <thead>
@@ -31,7 +31,7 @@
                 {% for i in range(1, 19) %}
                 <tr>
                     <td>{{ i }}</td>
-                    <td><input type="number" name="par_{{ i }}" required></td>
+                    <td><input type="number" name="par_{{ i }}" step="1" required></td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
## Summary
- enforce integer parsing for tour fields
- ensure number inputs only allow integer step

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685187b4d13883328c1104ee9855a607