### PR TITLE
Add par inputs and stats summary

### DIFF
--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -30,10 +30,10 @@
                 {% for i in range(1, 19) %}
                 <tr>
                     <td>{{ i }}</td>
-                    <td>{{ tour.pars[i-1] }}</td>
+                    <td><input type="number" name="par_{{ i }}" id="par_{{ i }}" min="3" max="5" step="1" value="{{ tour.pars[i-1] }}" required></td>
                     <td><input type="number" name="strokes_{{ i }}" step="1" required></td>
-                    <td><input type="checkbox" name="fairway_{{ i }}"></td>
-                    <td><input type="checkbox" name="gir_{{ i }}"></td>
+                    <td><input type="checkbox" id="fairway_{{ i }}" name="fairway_{{ i }}"></td>
+                    <td><input type="checkbox" name="gir_{{ i }}" id="gir_{{ i }}"></td>
                     <td><input type="number" name="putts_{{ i }}" step="1" required></td>
                     <td><input type="number" name="given_{{ i }}" step="1" required></td>
                 </tr>
@@ -43,5 +43,31 @@
         <button type="submit">Enregistrer</button>
     </form>
 </main>
+<script>
+function updateFairway(i){
+    var parInput = document.getElementById('par_' + i);
+    var fairway = document.getElementById('fairway_' + i);
+    if(parInput && fairway){
+        if(parInput.value == '3'){
+            fairway.checked = false;
+            fairway.disabled = true;
+        } else {
+            fairway.disabled = false;
+        }
+    }
+}
+document.addEventListener('DOMContentLoaded', function(){
+    for(var i = 1; i <= 18; i++){
+        updateFairway(i);
+        var p = document.getElementById('par_' + i);
+        if(p){
+            p.addEventListener('input', function(e){
+                var index = this.id.split('_')[1];
+                updateFairway(index);
+            });
+        }
+    }
+});
+</script>
 </body>
 </html>

--- a/templates/score_summary.html
+++ b/templates/score_summary.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Statistiques</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/">Accueil</a>
+    </nav>
+</header>
+<main>
+    <h1>Statistiques du tour</h1>
+    <p>Fairways touchés : {{ stats.fairway }}</p>
+    <p>Nombre total de putts : {{ stats.putts_total }} (moyenne {{ stats.putts_avg }})</p>
+    <p>Greens en régulation : {{ stats.gir }}</p>
+    <a href="/">Retour à l'accueil</a>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow entering par per hole when adding a score
- disable fairway checkbox automatically on par 3 holes
- compute and show stats after saving a score

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68518b714710833296ba62ab0f9e4500