### PR TITLE
Add golf management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # WHS Golf Tracking Application
 
 This Flask app lets you record golf rounds and scores.
+You can also manage information about each golf course.
 
 Key features:
 - Add a tour with per-hole par values.
+- Manage golf courses (name, course, par, slope and SSS).
 - Input scores for each hole of a tour.
 - View existing tours from the home page.
 

--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -9,6 +9,7 @@
 <header>
     <nav>
         <a href="/">Accueil</a>
+        <a href="/golf">Gérer les Golfs</a>
     </nav>
 </header>
 <main>

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -9,13 +9,22 @@
 <header>
     <nav>
         <a href="/">Accueil</a>
+        <a href="/golf">Gérer les Golfs</a>
     </nav>
 </header>
 <main>
     <h1>Ajouter un Tour</h1>
     <form method="post">
         <label>Nom du Tour <input type="text" name="name" required></label><br>
-        <label>Golf joué <input type="text" name="golf" required></label><br>
+        <label>Golf joué 
+            <select name="golf" id="golf_select" required>
+                <option value="">--Choisir--</option>
+                {% for g in golfs %}
+                <option value="{{ g.doc_id }}">{{ g.name }}</option>
+                {% endfor %}
+            </select>
+            <a href="/golf">+</a>
+        </label><br>
         <label>Par du parcours <input type="number" name="par" step="1" required></label><br>
         <label>Slope <input type="number" name="slope" step="1" required></label><br>
         <label>SSS <input type="number" name="sss" step="1" required></label><br>
@@ -39,5 +48,26 @@
         <button type="submit">Enregistrer</button>
     </form>
 </main>
+<script>
+    const golfData = {{ golfs|tojson }};
+    function updateGolfInfo(id){
+        const g = golfData.find(x => x.doc_id == id);
+        if(!g) return;
+        document.querySelector('input[name="par"]').value = g.par;
+        document.querySelector('input[name="slope"]').value = g.slope;
+        document.querySelector('input[name="sss"]').value = g.sss;
+    }
+    document.addEventListener('DOMContentLoaded', function(){
+        const select = document.getElementById('golf_select');
+        if(select){
+            select.addEventListener('change', function(){
+                updateGolfInfo(parseInt(this.value));
+            });
+            if(select.value){
+                updateGolfInfo(parseInt(select.value));
+            }
+        }
+    });
+</script>
 </body>
 </html>

--- a/templates/golf_form.html
+++ b/templates/golf_form.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestion Golf</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/">Accueil</a>
+        <a href="/add_tour">Ajouter un Tour</a>
+    </nav>
+</header>
+<main>
+    <h1>{% if golf %}Modifier le Golf{% else %}Ajouter un Golf{% endif %}</h1>
+    <form method="post">
+        {% if golf %}
+        <input type="hidden" name="id" value="{{ golf.doc_id }}">
+        {% endif %}
+        <label>Nom du Golf <input type="text" name="name" value="{{ golf.name if golf else '' }}" required></label><br>
+        <label>Nom du Parcours <input type="text" name="course" value="{{ golf.course if golf else '' }}" required></label><br>
+        <label>Par du parcours <input type="number" name="par" step="1" value="{{ golf.par if golf else '' }}" required></label><br>
+        <label>Boules de départ <input type="text" name="tees" value="{{ golf.tees if golf else '' }}" required></label><br>
+        <label>Slope <input type="number" name="slope" step="1" value="{{ golf.slope if golf else '' }}" required></label><br>
+        <label>SSS <input type="number" name="sss" step="1" value="{{ golf.sss if golf else '' }}" required></label><br>
+        <button type="submit">Enregistrer</button>
+    </form>
+</main>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
 <header>
     <nav>
         <a href="/add_tour">Ajouter un Tour</a>
+        <a href="/golf">Gérer les Golfs</a>
     </nav>
 </header>
 <main>
@@ -16,7 +17,12 @@
     <ul>
         {% for tour in tours %}
         <li>
-            {{ tour.name }} - <a href="/add_score/{{ tour.doc_id }}">Saisir Score</a>
+            {{ tour.name }}
+            {% set g = golfs.get(tour.golf_id) %}
+            {% if g %}
+                ({{ g.name }})
+            {% endif %}
+             - <a href="/add_score/{{ tour.doc_id }}">Saisir Score</a>
         </li>
         {% else %}
         <li>Aucun tour enregistré.</li>

--- a/templates/score_summary.html
+++ b/templates/score_summary.html
@@ -9,6 +9,7 @@
 <header>
     <nav>
         <a href="/">Accueil</a>
+        <a href="/golf">Gérer les Golfs</a>
     </nav>
 </header>
 <main>


### PR DESCRIPTION
## Summary
- manage golf data in TinyDB
- integrate golf selection when adding a tour
- show golf names on the home page
- update navigation links

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68518e9e60c08332a45b58b23972a7e4