### PR TITLE
Add CRUD operations for golf tours

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This Flask app lets you record golf rounds and scores.
 You can also manage information about each golf course.
 
 Key features:
-- Add a tour with per-hole par values.
+- Full CRUD management for tours with per-hole par values.
 - Manage golf courses (name, course, par, slope and SSS).
 - Input scores for each hole of a tour.
-- View existing tours from the home page.
+- View, edit and delete existing tours from the home page.
 
 Install dependencies with:
 ```

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
     <meta charset="UTF-8">
-    <title>Ajouter un Tour</title>
+    <title>{% if tour %}Modifier le Tour{% else %}Ajouter un Tour{% endif %}</title>
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
@@ -13,21 +13,24 @@
     </nav>
 </header>
 <main>
-    <h1>Ajouter un Tour</h1>
+    <h1>{% if tour %}Modifier le Tour{% else %}Ajouter un Tour{% endif %}</h1>
     <form method="post">
-        <label>Nom du Tour <input type="text" name="name" required></label><br>
+        {% if tour %}
+        <input type="hidden" name="id" value="{{ tour.doc_id }}">
+        {% endif %}
+        <label>Nom du Tour <input type="text" name="name" value="{{ tour.name if tour else '' }}" required></label><br>
         <label>Golf joué 
             <select name="golf" id="golf_select" required>
                 <option value="">--Choisir--</option>
                 {% for g in golfs %}
-                <option value="{{ g.doc_id }}">{{ g.name }}</option>
+                <option value="{{ g.doc_id }}" {% if tour and tour.golf_id == g.doc_id %}selected{% endif %}>{{ g.name }}</option>
                 {% endfor %}
             </select>
             <a href="/golf">+</a>
         </label><br>
-        <label>Par du parcours <input type="number" name="par" step="1" required></label><br>
-        <label>Slope <input type="number" name="slope" step="1" required></label><br>
-        <label>SSS <input type="number" name="sss" step="1" required></label><br>
+        <label>Par du parcours <input type="number" name="par" step="1" value="{{ tour.par if tour else '' }}" required></label><br>
+        <label>Slope <input type="number" name="slope" step="1" value="{{ tour.slope if tour else '' }}" required></label><br>
+        <label>SSS <input type="number" name="sss" step="1" value="{{ tour.sss if tour else '' }}" required></label><br>
         <h2>Par par trou</h2>
         <table>
             <thead>
@@ -40,12 +43,15 @@
                 {% for i in range(1, 19) %}
                 <tr>
                     <td>{{ i }}</td>
-                    <td><input type="number" name="par_{{ i }}" step="1" required></td>
+                    <td><input type="number" name="par_{{ i }}" step="1" value="{{ tour.pars[i-1] if tour and tour.pars else '' }}" required></td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
         <button type="submit">Enregistrer</button>
+        {% if tour %}
+        <a href="{{ url_for('add_tour') }}">Annuler</a>
+        {% endif %}
     </form>
 </main>
 <script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,20 +14,35 @@
 </header>
 <main>
     <h1>Liste des Tours</h1>
-    <ul>
-        {% for tour in tours %}
-        <li>
-            {{ tour.name }}
-            {% set g = golfs.get(tour.golf_id) %}
-            {% if g %}
-                ({{ g.name }})
-            {% endif %}
-             - <a href="/add_score/{{ tour.doc_id }}">Saisir Score</a>
-        </li>
-        {% else %}
-        <li>Aucun tour enregistré.</li>
-        {% endfor %}
-    </ul>
+    <table>
+        <thead>
+            <tr>
+                <th>Nom</th>
+                <th>Golf</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for tour in tours %}
+            <tr>
+                <td>{{ tour.name }}</td>
+                <td>
+                    {% set g = golfs.get(tour.golf_id) %}
+                    {{ g.name if g }}
+                </td>
+                <td>
+                    <a href="{{ url_for('add_tour', id=tour.doc_id) }}">Modifier</a>
+                    <form action="{{ url_for('delete_tour', tour_id=tour.doc_id) }}" method="post" style="display:inline;">
+                        <button type="submit" onclick="return confirm('Supprimer ce tour ?');">Supprimer</button>
+                    </form>
+                    <a href="{{ url_for('add_score', tour_id=tour.doc_id) }}">Saisir Score</a>
+                </td>
+            </tr>
+            {% else %}
+            <tr><td colspan="3">Aucun tour enregistré.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance `/add_tour` route to create, update and delete tours
- add delete endpoint for tours
- update Add Tour form to support editing
- show tour list with edit/delete actions on home page
- document new CRUD capabilities in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851944160788332a3449f7c2ddf1e8e