### PR TITLE
Fix SSS prefill in add_tour

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ def manage_golf():
             'par': request.form.get('par', type=int),
             'tees': request.form.get('tees'),
             'slope': request.form.get('slope', type=int),
-            'sss': request.form.get('sss', type=int)
+            'sss': request.form.get('sss', type=float)
         }
         if form_id:
             golfs_table.update(data, doc_ids=[form_id])
@@ -59,7 +59,7 @@ def add_tour():
             'golf_id': request.form.get('golf', type=int),
             'par': request.form.get('par', type=int),
             'slope': request.form.get('slope', type=int),
-            'sss': request.form.get('sss', type=int),
+            'sss': request.form.get('sss', type=float),
             'pars': pars,
         }
         if form_id:

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -30,7 +30,7 @@
         </label><br>
         <label>Par du parcours <input type="number" name="par" step="1" value="{{ tour.par if tour else '' }}" required></label><br>
         <label>Slope <input type="number" name="slope" step="1" value="{{ tour.slope if tour else '' }}" required></label><br>
-        <label>SSS <input type="number" name="sss" step="1" value="{{ tour.sss if tour else '' }}" required></label><br>
+        <label>SSS <input type="number" name="sss" step="0.1" value="{{ tour.sss if tour else '' }}" required></label><br>
         <h2>Par par trou</h2>
         <table>
             <thead>

--- a/templates/golf_form.html
+++ b/templates/golf_form.html
@@ -23,8 +23,8 @@
         <label>Par du parcours <input type="number" name="par" step="1" value="{{ golf.par if golf else '' }}" required></label><br>
         <label>Boules de départ <input type="text" name="tees" value="{{ golf.tees if golf else '' }}" required></label><br>
         <label>Slope <input type="number" name="slope" step="1" value="{{ golf.slope if golf else '' }}" required></label><br>
-        <!-- SSS can contain decimal values so use a text field -->
-        <label>SSS <input type="text" name="sss" value="{{ golf.sss if golf else '' }}" required></label><br>
+        <!-- SSS may be decimal so allow fractional numbers -->
+        <label>SSS <input type="number" name="sss" step="0.1" value="{{ golf.sss if golf else '' }}" required></label><br>
         <button type="submit">Enregistrer</button>
         {% if golf %}
         <a href="{{ url_for('manage_golf') }}">Annuler</a>


### PR DESCRIPTION
## Summary
- allow decimal SSS values when saving a golf or a tour
- accept fractional input for SSS fields in forms

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851953c6d488332a3b3c7ef0bdf3bfe