### PR TITLE
Refactor score entry layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,13 +95,20 @@ def add_score(tour_id):
         holes = []
         for i in range(1, 19):
             par = request.form.get(f'par_{i}', type=int)
+            strokes = request.form.get(f'strokes_{i}', type=int)
+            given = request.form.get(f'given_{i}', type=int)
+            adjusted = request.form.get(f'adjusted_{i}', type=int)
+            if adjusted is None and par is not None and strokes is not None and given is not None:
+                limit = par + 2 + given
+                adjusted = min(strokes, limit)
             hole = {
                 'par': par,
-                'strokes': request.form.get(f'strokes_{i}', type=int),
+                'strokes_given': given,
+                'strokes': strokes,
+                'adjusted': adjusted,
                 'fairway': bool(request.form.get(f'fairway_{i}')),
                 'gir': bool(request.form.get(f'gir_{i}')),
-                'putts': request.form.get(f'putts_{i}', type=int),
-                'strokes_given': request.form.get(f'given_{i}', type=int)
+                'putts': request.form.get(f'putts_{i}', type=int)
             }
             holes.append(hole)
         score = {

--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -18,27 +18,55 @@
         <table>
             <thead>
                 <tr>
-                    <th>Trou</th>
-                    <th>Par</th>
-                    <th>Coups</th>
-                    <th>Fairway</th>
-                    <th>Green en régulation</th>
-                    <th>Putt</th>
-                    <th>Coups rendus</th>
+                    <th></th>
+                    {% for i in range(1, 19) %}
+                    <th>{{ i }}</th>
+                    {% endfor %}
                 </tr>
             </thead>
             <tbody>
-                {% for i in range(1, 19) %}
                 <tr>
-                    <td>{{ i }}</td>
-                    <td><input type="number" name="par_{{ i }}" id="par_{{ i }}" min="3" max="5" step="1" value="{{ tour.pars[i-1] }}" required></td>
-                    <td><input type="number" name="strokes_{{ i }}" step="1" required></td>
-                    <td><input type="checkbox" id="fairway_{{ i }}" name="fairway_{{ i }}"></td>
-                    <td><input type="checkbox" name="gir_{{ i }}" id="gir_{{ i }}"></td>
-                    <td><input type="number" name="putts_{{ i }}" step="1" required></td>
-                    <td><input type="number" name="given_{{ i }}" step="1" required></td>
+                    <th>Par</th>
+                    {% for i in range(1, 19) %}
+                    <td><input type="number" name="par_{{ i }}" id="par_{{ i }}" step="1" value="{{ tour.pars[i-1] }}" required></td>
+                    {% endfor %}
                 </tr>
-                {% endfor %}
+                <tr>
+                    <th>Coups reçus</th>
+                    {% for i in range(1, 19) %}
+                    <td><input type="number" name="given_{{ i }}" id="given_{{ i }}" step="1" required></td>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th>Score</th>
+                    {% for i in range(1, 19) %}
+                    <td><input type="number" name="strokes_{{ i }}" id="strokes_{{ i }}" step="1" required></td>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th>Score brut ajusté</th>
+                    {% for i in range(1, 19) %}
+                    <td><input type="number" name="adjusted_{{ i }}" id="adjusted_{{ i }}" readonly></td>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th>Fairway touché</th>
+                    {% for i in range(1, 19) %}
+                    <td><input type="checkbox" id="fairway_{{ i }}" name="fairway_{{ i }}"></td>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th>Green en régulation</th>
+                    {% for i in range(1, 19) %}
+                    <td><input type="checkbox" name="gir_{{ i }}" id="gir_{{ i }}"></td>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th>Nb de Putts</th>
+                    {% for i in range(1, 19) %}
+                    <td><input type="number" name="putts_{{ i }}" id="putts_{{ i }}" step="1" required></td>
+                    {% endfor %}
+                </tr>
             </tbody>
         </table>
         <button type="submit">Enregistrer</button>
@@ -49,7 +77,7 @@ function updateFairway(i){
     var parInput = document.getElementById('par_' + i);
     var fairway = document.getElementById('fairway_' + i);
     if(parInput && fairway){
-        if(parInput.value == '3'){
+        if(parseInt(parInput.value) <= 3){
             fairway.checked = false;
             fairway.disabled = true;
         } else {
@@ -57,16 +85,32 @@ function updateFairway(i){
         }
     }
 }
+
+function computeAdjusted(i){
+    var par = parseInt(document.getElementById('par_' + i).value) || 0;
+    var given = parseInt(document.getElementById('given_' + i).value) || 0;
+    var strokes = parseInt(document.getElementById('strokes_' + i).value) || 0;
+    var limit = par + 2 + given;
+    var adjusted = Math.min(strokes, limit);
+    var field = document.getElementById('adjusted_' + i);
+    if(field){
+        field.value = adjusted;
+    }
+}
+
 document.addEventListener('DOMContentLoaded', function(){
     for(var i = 1; i <= 18; i++){
         updateFairway(i);
-        var p = document.getElementById('par_' + i);
-        if(p){
-            p.addEventListener('input', function(e){
-                var index = this.id.split('_')[1];
-                updateFairway(index);
-            });
-        }
+        computeAdjusted(i);
+        ['par_', 'given_', 'strokes_'].forEach(function(prefix){
+            var el = document.getElementById(prefix + i);
+            if(el){
+                el.addEventListener('input', function(){
+                    updateFairway(i);
+                    computeAdjusted(i);
+                });
+            }
+        });
     }
 });
 </script>


### PR DESCRIPTION
## Summary
- redesign add score form to be hole columns and metric rows
- compute net double bogey per hole
- store adjusted score in DB

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68519811bd408332b396810b635f4418