### PR TITLE
Enable editing of saved scorecards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/app.py
+++ b/app.py
@@ -91,6 +91,9 @@ def add_score(tour_id):
     tour = tours_table.get(doc_id=tour_id)
     if not tour:
         return redirect(url_for('index'))
+    # Retrieve existing score for this tour if any
+    Score = Query()
+    existing_score = scores_table.get(Score.tour_id == tour_id)
     if request.method == 'POST':
         holes = []
         for i in range(1, 19):
@@ -115,7 +118,11 @@ def add_score(tour_id):
             'tour_id': tour_id,
             'holes': holes
         }
-        scores_table.insert(score)
+        # Insert or update the score so data is persisted
+        if existing_score:
+            scores_table.update(score, doc_ids=[existing_score.doc_id])
+        else:
+            scores_table.insert(score)
 
         fairway_possible = sum(1 for h in holes if h['par'] != 3)
         fairway_hits = sum(1 for h in holes if h['par'] != 3 and h['fairway'])
@@ -133,7 +140,7 @@ def add_score(tour_id):
         return render_template('score_summary.html', stats=stats)
     if 'pars' not in tour:
         tour['pars'] = [4] * 18
-    return render_template('add_score.html', tour=tour)
+    return render_template('add_score.html', tour=tour, score=existing_score)
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -15,6 +15,9 @@
 <main>
     <h1>Saisir Score pour {{ tour.name }}</h1>
     <form method="post">
+        {% if score %}
+        <input type="hidden" name="id" value="{{ score.doc_id }}">
+        {% endif %}
         <table>
             <thead>
                 <tr>
@@ -28,43 +31,43 @@
                 <tr>
                     <th>Par</th>
                     {% for i in range(1, 19) %}
-                    <td><input type="number" name="par_{{ i }}" id="par_{{ i }}" step="1" value="{{ tour.pars[i-1] }}" required></td>
+                    <td><input type="number" name="par_{{ i }}" id="par_{{ i }}" step="1" value="{{ score.holes[i-1].par if score else tour.pars[i-1] }}" required></td>
                     {% endfor %}
                 </tr>
                 <tr>
                     <th>Coups reçus</th>
                     {% for i in range(1, 19) %}
-                    <td><input type="number" name="given_{{ i }}" id="given_{{ i }}" step="1" required></td>
+                    <td><input type="number" name="given_{{ i }}" id="given_{{ i }}" step="1" value="{{ score.holes[i-1].strokes_given if score else '' }}" required></td>
                     {% endfor %}
                 </tr>
                 <tr>
                     <th>Score</th>
                     {% for i in range(1, 19) %}
-                    <td><input type="number" name="strokes_{{ i }}" id="strokes_{{ i }}" step="1" required></td>
+                    <td><input type="number" name="strokes_{{ i }}" id="strokes_{{ i }}" step="1" value="{{ score.holes[i-1].strokes if score else '' }}" required></td>
                     {% endfor %}
                 </tr>
                 <tr>
                     <th>Score brut ajusté</th>
                     {% for i in range(1, 19) %}
-                    <td><input type="number" name="adjusted_{{ i }}" id="adjusted_{{ i }}" readonly></td>
+                    <td><input type="number" name="adjusted_{{ i }}" id="adjusted_{{ i }}" value="{{ score.holes[i-1].adjusted if score else '' }}" readonly></td>
                     {% endfor %}
                 </tr>
                 <tr>
                     <th>Fairway touché</th>
                     {% for i in range(1, 19) %}
-                    <td><input type="checkbox" id="fairway_{{ i }}" name="fairway_{{ i }}"></td>
+                    <td><input type="checkbox" id="fairway_{{ i }}" name="fairway_{{ i }}" {% if score and score.holes[i-1].fairway %}checked{% endif %}></td>
                     {% endfor %}
                 </tr>
                 <tr>
                     <th>Green en régulation</th>
                     {% for i in range(1, 19) %}
-                    <td><input type="checkbox" name="gir_{{ i }}" id="gir_{{ i }}"></td>
+                    <td><input type="checkbox" name="gir_{{ i }}" id="gir_{{ i }}" {% if score and score.holes[i-1].gir %}checked{% endif %}></td>
                     {% endfor %}
                 </tr>
                 <tr>
                     <th>Nb de Putts</th>
                     {% for i in range(1, 19) %}
-                    <td><input type="number" name="putts_{{ i }}" id="putts_{{ i }}" step="1" required></td>
+                    <td><input type="number" name="putts_{{ i }}" id="putts_{{ i }}" step="1" value="{{ score.holes[i-1].putts if score else '' }}" required></td>
                     {% endfor %}
                 </tr>
             </tbody>


### PR DESCRIPTION
## Summary
- persist scorecards in `scores` table
- pre-fill score form with existing data
- update score entry instead of always inserting
- add `.gitignore`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68519a66118c83328eb5a58320bea007