### PR TITLE
Add jour field to tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Flask app lets you record golf rounds and scores.
 You can also manage information about each golf course.
 
 Key features:
-- Full CRUD management for tours with per-hole par values.
+- Full CRUD management for tours with per-hole par values and a day number.
 - Manage golf courses (name, course, par, slope and SSS).
 - Input scores for each hole of a tour.
 - View, edit and delete existing tours from the home page.

--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ def add_tour():
         pars = [request.form.get(f'par_{i}', type=int) for i in range(1, 19)]
         tour = {
             'name': request.form.get('name'),
+            'jour': request.form.get('jour', type=int),
             'golf_id': request.form.get('golf', type=int),
             'par': request.form.get('par', type=int),
             'slope': request.form.get('slope', type=int),

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -19,7 +19,8 @@
         <input type="hidden" name="id" value="{{ tour.doc_id }}">
         {% endif %}
         <label>Nom du Tour <input type="text" name="name" value="{{ tour.name if tour else '' }}" required></label><br>
-        <label>Golf joué 
+        <label>Jour <input type="number" name="jour" step="1" value="{{ tour.get('jour') if tour else '' }}" required></label><br>
+        <label>Golf joué
             <select name="golf" id="golf_select" required>
                 <option value="">--Choisir--</option>
                 {% for g in golfs %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,7 @@
         <thead>
             <tr>
                 <th>Nom</th>
+                <th>Jour</th>
                 <th>Golf</th>
                 <th>Actions</th>
             </tr>
@@ -26,6 +27,7 @@
             {% for tour in tours %}
             <tr>
                 <td>{{ tour.name }}</td>
+                <td>{{ tour.get('jour') }}</td>
                 <td>
                     {% set g = golfs.get(tour.golf_id) %}
                     {{ g.name if g }}
@@ -39,7 +41,7 @@
                 </td>
             </tr>
             {% else %}
-            <tr><td colspan="3">Aucun tour enregistré.</td></tr>
+            <tr><td colspan="4">Aucun tour enregistré.</td></tr>
             {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- add `jour` column in index table
- add day number field to tour form
- store the day number when saving a tour
- document new field in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68519caf762c8332971e7ab98a2dd41b