### PR TITLE
Add quick start score route

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Key features:
 - Full CRUD management for tours with per-hole par values and a day number.
 - Manage golf courses (name, course, par, slope, SSS and per-hole pars).
 - Input scores for each hole of a tour.
+- Quick creation of a tour using "Nouvelle Carte" to jump directly to score entry.
 - View, edit and delete existing tours from the home page.
 - Statistics for each scorecard are stored in their own TinyDB index.
 

--- a/app.py
+++ b/app.py
@@ -17,6 +17,30 @@ def index():
     golfs = {g.doc_id: g for g in golfs_table.all()}
     return render_template('index.html', tours=tours_table.all(), golfs=golfs)
 
+@app.route('/start_score', methods=['GET', 'POST'])
+def start_score():
+    """Create a tour with default par data and go directly to score entry."""
+    if request.method == 'POST':
+        golf_id = request.form.get('golf', type=int)
+        name = request.form.get('name')
+        jour = request.form.get('jour', type=int)
+        golf = golfs_table.get(doc_id=golf_id)
+        if golf:
+            pars = golf.get('pars', [4] * 18)
+            tour = {
+                'name': name,
+                'jour': jour,
+                'golf_id': golf_id,
+                'par': golf.get('par'),
+                'slope': golf.get('slope'),
+                'sss': golf.get('sss'),
+                'pars': pars,
+            }
+            tour_id = tours_table.insert(tour)
+            return redirect(url_for('add_score', tour_id=tour_id))
+    golfs = golfs_table.all()
+    return render_template('start_score.html', golfs=golfs)
+
 @app.route('/golf', methods=['GET', 'POST'])
 def manage_golf():
     """Create or update a golf and display the list of existing ones."""

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
 <header>
     <nav>
         <a href="/add_tour">Ajouter un Tour</a>
+        <a href="/start_score">Nouvelle Carte</a>
         <a href="/golf">Gérer les Golfs</a>
     </nav>
 </header>

--- a/templates/start_score.html
+++ b/templates/start_score.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Nouvelle Carte</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/">Accueil</a>
+        <a href="/golf">Gérer les Golfs</a>
+    </nav>
+</header>
+<main>
+    <h1>Nouvelle Carte</h1>
+    <form method="post">
+        <label>Nom du Tour <input type="text" name="name" required></label><br>
+        <label>Jour <input type="number" name="jour" step="1" required></label><br>
+        <label>Golf joué
+            <select name="golf" required>
+                <option value="">--Choisir--</option>
+                {% for g in golfs %}
+                <option value="{{ g.doc_id }}">{{ g.name }}</option>
+                {% endfor %}
+            </select>
+            <a href="/golf">+</a>
+        </label><br>
+        <button type="submit">Commencer la Saisie du Score</button>
+    </form>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow fast score entry with `/start_score`
- link to the new page from the home page
- document quick start feature in README

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68526ac8f5a083329a1980a21cac2f91