### PR TITLE
Add global statistics page

### DIFF
--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/stats">Statistiques</a>
     </nav>
 </header>
 <main>

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/stats">Statistiques</a>
     </nav>
 </header>
 <main>

--- a/templates/golf_form.html
+++ b/templates/golf_form.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/add_tour">Ajouter un Tour</a>
+        <a href="/stats">Statistiques</a>
     </nav>
 </header>
 <main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,7 @@
         <a href="/add_tour">Ajouter un Tour</a>
         <a href="/start_score">Nouvelle Carte</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/stats">Statistiques</a>
     </nav>
 </header>
 <main>

--- a/templates/score_summary.html
+++ b/templates/score_summary.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/stats">Statistiques</a>
     </nav>
 </header>
 <main>

--- a/templates/start_score.html
+++ b/templates/start_score.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/stats">Statistiques</a>
     </nav>
 </header>
 <main>

--- a/templates/stats_overall.html
+++ b/templates/stats_overall.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Statistiques Globales</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/">Accueil</a>
+        <a href="/golf">Gérer les Golfs</a>
+    </nav>
+</header>
+<main>
+    <h1>Statistiques Globales</h1>
+    <p>Moyenne des putts : {{ stats.avg_putts }}</p>
+    <p>Moyenne des scores : {{ stats.avg_score }}</p>
+    <p>Moyenne des fairways touchés : {{ stats.avg_fairways }}</p>
+    <p>Nombre total de GIR : {{ stats.total_gir }}</p>
+    <p>Moyenne du SBA : {{ stats.avg_sba }}</p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/stats` route to display overall stats
- create `stats_overall.html` template
- link stats page in navigation

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685274068f508332944a6cbf87ead8ed