### PR TITLE
Add global putts statistic

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,6 +187,15 @@ def add_score(tour_id):
         else:
             stats_table.insert(stats_data)
 
+        # Calculate average putts per card across all recorded cards
+        stats_entries = stats_table.all()
+        num_cards_overall = len(stats_entries)
+        if num_cards_overall:
+            avg_putts_cards = sum(s.get('putts_total', 0) / 18 for s in stats_entries) / num_cards_overall
+            stats['putts_avg_cards'] = format(avg_putts_cards, '.1f')
+        else:
+            stats['putts_avg_cards'] = '0.0'
+
         return render_template('score_summary.html', stats=stats)
     if 'pars' not in tour:
         tour['pars'] = [4] * 18

--- a/templates/score_summary.html
+++ b/templates/score_summary.html
@@ -16,7 +16,7 @@
 <main>
     <h1>Statistiques du tour</h1>
     <p>Fairways touchés : {{ stats.fairway }}</p>
-    <p>Nombre total de putts : {{ stats.putts_total }} (moyenne {{ stats.putts_avg }})</p>
+    <p>Nombre total de putts : {{ stats.putts_total }} (moyenne {{ stats.putts_avg }}, moy. cartes {{ stats.putts_avg_cards }})</p>
     <p>Greens en régulation : {{ stats.gir }}</p>
     <a href="/">Retour à l'accueil</a>
 </main>


### PR DESCRIPTION
## Summary
- compute average putts per card across all recorded scorecards
- display the value on the score summary page

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685278c63aa88332b3495c0cc8869fb1