### PR TITLE
Add average putts per card in stats

### DIFF
--- a/app.py
+++ b/app.py
@@ -222,12 +222,16 @@ def overall_stats():
         total_sba += sum((h.get('adjusted') if h.get('adjusted') is not None else 0) for h in holes)
 
     avg_putts = format(total_putts / num_cards, '.1f') if num_cards else '0.0'
+    avg_putts_cards = (
+        format(total_putts / (num_cards * 18), '.1f') if num_cards else '0.0'
+    )
     avg_score = format(total_scores / num_cards, '.1f') if num_cards else '0.0'
     avg_fairways = format(total_fairway_hits / num_cards, '.1f') if num_cards else '0.0'
     avg_sba = format(total_sba / num_cards, '.1f') if num_cards else '0.0'
 
     stats = {
         'avg_putts': avg_putts,
+        'avg_putts_cards': avg_putts_cards,
         'avg_score': avg_score,
         'avg_fairways': avg_fairways,
         'total_gir': total_gir_hits,

--- a/templates/stats_overall.html
+++ b/templates/stats_overall.html
@@ -14,7 +14,7 @@
 </header>
 <main>
     <h1>Statistiques Globales</h1>
-    <p>Moyenne des putts : {{ stats.avg_putts }}</p>
+    <p>Moyenne des putts : {{ stats.avg_putts }} (moy. cartes {{ stats.avg_putts_cards }})</p>
     <p>Moyenne des scores : {{ stats.avg_score }}</p>
     <p>Moyenne des fairways touchés : {{ stats.avg_fairways }}</p>
     <p>Nombre total de GIR : {{ stats.total_gir }}</p>


### PR DESCRIPTION
## Summary
- calculate average putts per hole across all cards
- show the overall average on the stats page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68527a1fb20c8332a953551e5b79ab0e