### PR TITLE
Add score totals in tour listings

### DIFF
--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/scores">Cartes</a>
         <a href="/stats">Statistiques</a>
     </nav>
 </header>

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/scores">Cartes</a>
         <a href="/stats">Statistiques</a>
     </nav>
 </header>

--- a/templates/golf_form.html
+++ b/templates/golf_form.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/add_tour">Ajouter un Tour</a>
+        <a href="/scores">Cartes</a>
         <a href="/stats">Statistiques</a>
     </nav>
 </header>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,7 @@
         <a href="/add_tour">Ajouter un Tour</a>
         <a href="/start_score">Nouvelle Carte</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/scores">Cartes</a>
         <a href="/stats">Statistiques</a>
     </nav>
 </header>
@@ -22,6 +23,8 @@
                 <th>Nom</th>
                 <th>Jour</th>
                 <th>Golf</th>
+                <th>Total Score</th>
+                <th>Total SBA</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -34,6 +37,8 @@
                     {% set g = golfs.get(tour.golf_id) %}
                     {{ g.name if g }}
                 </td>
+                <td>{{ tour.total_score if tour.total_score is not none else '' }}</td>
+                <td>{{ tour.total_sba if tour.total_sba is not none else '' }}</td>
                 <td>
                     <a href="{{ url_for('add_score', tour_id=tour.doc_id) }}">Modifier</a>
                     <form action="{{ url_for('delete_tour', tour_id=tour.doc_id) }}" method="post" style="display:inline;">
@@ -43,7 +48,7 @@
                 </td>
             </tr>
             {% else %}
-            <tr><td colspan="4">Aucun tour enregistré.</td></tr>
+            <tr><td colspan="6">Aucun tour enregistré.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/templates/score_summary.html
+++ b/templates/score_summary.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/scores">Cartes</a>
         <a href="/stats">Statistiques</a>
     </nav>
 </header>

--- a/templates/scores_list.html
+++ b/templates/scores_list.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Cartes enregistrées</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/">Accueil</a>
+        <a href="/golf">Gérer les Golfs</a>
+        <a href="/scores">Cartes</a>
+        <a href="/stats">Statistiques</a>
+    </nav>
+</header>
+<main>
+    <h1>Cartes enregistrées</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Nom</th>
+                <th>Jour</th>
+                <th>Golf</th>
+                <th>Total Score</th>
+                <th>Total SBA</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for c in cards %}
+            <tr>
+                <td>{{ c.tour.name }}</td>
+                <td>{{ c.tour.get('jour') }}</td>
+                <td>{{ c.golf.name if c.golf }}</td>
+                <td>{{ c.total_score }}</td>
+                <td>{{ c.total_sba }}</td>
+            </tr>
+        {% else %}
+            <tr><td colspan="5">Aucune carte enregistrée.</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</main>
+</body>
+</html>

--- a/templates/start_score.html
+++ b/templates/start_score.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/scores">Cartes</a>
         <a href="/stats">Statistiques</a>
     </nav>
 </header>

--- a/templates/stats_overall.html
+++ b/templates/stats_overall.html
@@ -10,6 +10,7 @@
     <nav>
         <a href="/">Accueil</a>
         <a href="/golf">Gérer les Golfs</a>
+        <a href="/scores">Cartes</a>
     </nav>
 </header>
 <main>


### PR DESCRIPTION
## Summary
- show total strokes and SBA on the home page
- add a list of recorded scorecards with totals
- link to the new list from navigation menus

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6852837590a88332a7d3315275dbbb01