### PR TITLE
Fix automatic SBA computation on save

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,7 +151,11 @@ def add_score(tour_id):
             strokes = request.form.get(f'strokes_{i}', type=int)
             given = request.form.get(f'given_{i}', type=int)
             adjusted = request.form.get(f'adjusted_{i}', type=int)
-            if adjusted is None and par is not None and strokes is not None and given is not None:
+
+            # Always recompute the adjusted score on the backend to
+            # ensure it is available even if the client-side script did
+            # not populate the value.
+            if par is not None and strokes is not None and given is not None:
                 limit = par + 2 + given
                 adjusted = min(strokes, limit)
             hole = {


### PR DESCRIPTION
## Summary
- recompute adjusted (SBA) score for each hole on the backend when saving scores

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68529a4e3c84833289f0d40e094a1221