### PR TITLE
Add tour date field

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Flask app lets you record golf rounds and scores.
 You can also manage information about each golf course.
 
 Key features:
-- Full CRUD management for tours with per-hole par values and a day number.
+- Full CRUD management for tours with per-hole par values, a day number and a date.
 - Manage golf courses (name, course, par, slope, SSS and per-hole pars).
 - Input scores for each hole of a tour.
 - Quick creation of a tour using "Nouvelle Carte" to jump directly to score entry.

--- a/app.py
+++ b/app.py
@@ -44,12 +44,14 @@ def start_score():
         golf_id = request.form.get('golf', type=int)
         name = request.form.get('name')
         jour = request.form.get('jour', type=int)
+        date = request.form.get('date')
         golf = golfs_table.get(doc_id=golf_id)
         if golf:
             pars = golf.get('pars', [4] * 18)
             tour = {
                 'name': name,
                 'jour': jour,
+                'date': date,
                 'golf_id': golf_id,
                 'par': golf.get('par'),
                 'slope': golf.get('slope'),
@@ -106,6 +108,7 @@ def add_tour():
         tour = {
             'name': request.form.get('name'),
             'jour': request.form.get('jour', type=int),
+            'date': request.form.get('date'),
             'golf_id': request.form.get('golf', type=int),
             'par': request.form.get('par', type=int),
             'slope': request.form.get('slope', type=int),

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -22,6 +22,7 @@
         {% endif %}
         <label>Nom du Tour <input type="text" name="name" value="{{ tour.name if tour else '' }}" required></label><br>
         <label>Jour <input type="number" name="jour" step="1" value="{{ tour.get('jour') if tour else '' }}" required></label><br>
+        <label>Date <input type="date" name="date" value="{{ tour.date if tour else '' }}" required></label><br>
         <label>Golf joué
             <select name="golf" id="golf_select" required>
                 <option value="">--Choisir--</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,7 @@
             <tr>
                 <th>Nom</th>
                 <th>Jour</th>
+                <th>Date</th>
                 <th>Golf</th>
                 <th>Total Score</th>
                 <th>Total SBA</th>
@@ -33,6 +34,7 @@
             <tr>
                 <td>{{ tour.name }}</td>
                 <td>{{ tour.get('jour') }}</td>
+                <td>{{ tour.get('date') }}</td>
                 <td>
                     {% set g = golfs.get(tour.golf_id) %}
                     {{ g.name if g }}
@@ -48,7 +50,7 @@
                 </td>
             </tr>
             {% else %}
-            <tr><td colspan="6">Aucun tour enregistré.</td></tr>
+            <tr><td colspan="7">Aucun tour enregistré.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/templates/start_score.html
+++ b/templates/start_score.html
@@ -19,6 +19,7 @@
     <form method="post">
         <label>Nom du Tour <input type="text" name="name" required></label><br>
         <label>Jour <input type="number" name="jour" step="1" required></label><br>
+        <label>Date <input type="date" name="date" required></label><br>
         <label>Golf joué
             <select name="golf" required>
                 <option value="">--Choisir--</option>


### PR DESCRIPTION
## Summary
- record a date for each tour in the `tours` table
- capture the date when creating or editing a tour
- show the date on the home page
- document the new date feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529dc42bf88332a58c1d4e37fcc883