### PR TITLE
Add PCC and WHS differential display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # WHS Golf Tracking Application
 
 This Flask app lets you record golf rounds and scores.
-You can also manage information about each golf course.
+You can also manage information about each golf course and track WHS differentials.
 
 Key features:
 - Full CRUD management for tours with per-hole par values, a day number and a date.
 - Manage golf courses (name, course, par, slope, SSS and per-hole pars).
 - Input scores for each hole of a tour.
+- PCC can be stored for each round to adjust the WHS differential.
 - Quick creation of a tour using "Nouvelle Carte" to jump directly to score entry.
 - View, edit and delete existing tours from the home page.
-- Statistics for each scorecard are stored in their own TinyDB index.
+- Statistics for each scorecard are stored in their own TinyDB index and the WHS differential is shown when viewing a card.
 
 Install dependencies with:
 ```

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -35,6 +35,7 @@
         <label>Par du parcours <input type="number" name="par" step="1" value="{{ tour.par if tour else '' }}" required></label><br>
         <label>Slope <input type="number" name="slope" step="1" value="{{ tour.slope if tour else '' }}" required></label><br>
         <label>SSS <input type="number" name="sss" step="0.1" value="{{ tour.sss if tour else '' }}" required></label><br>
+        <label>PCC <input type="number" name="pcc" step="0.1" value="{{ tour.pcc if tour else 0 }}" required></label><br>
         <h2>Par et HCP par trou</h2>
         <table>
             <thead>

--- a/templates/score_summary.html
+++ b/templates/score_summary.html
@@ -19,6 +19,7 @@
     <p>Fairways touchés : {{ stats.fairway }}</p>
     <p>Nombre total de putts : {{ stats.putts_total }} (moyenne {{ stats.putts_avg }}, moy. cartes {{ stats.putts_avg_cards }})</p>
     <p>Greens en régulation : {{ stats.gir }}</p>
+    {% if stats.diff_whs %}<p>Différentiel WHS : {{ stats.diff_whs }}</p>{% endif %}
     <a href="/">Retour à l'accueil</a>
 </main>
 </body>

--- a/templates/scores_list.html
+++ b/templates/scores_list.html
@@ -16,6 +16,16 @@
 </header>
 <main>
     <h1>Cartes enregistrées</h1>
+    <form method="get" style="margin-bottom:10px;">
+        <label>Index actuel <input type="number" step="0.1" name="index" value="{{ current_index if current_index is not none else '' }}"></label>
+        <label>Trier par
+            <select name="sort">
+                <option value="date" {% if sort == 'date' %}selected{% endif %}>Date</option>
+                <option value="diff" {% if sort == 'diff' %}selected{% endif %}>Différentiel</option>
+            </select>
+        </label>
+        <button type="submit">Appliquer</button>
+    </form>
     <table>
         <thead>
             <tr>
@@ -24,6 +34,7 @@
                 <th>Golf</th>
                 <th>Total Score</th>
                 <th>Total SBA</th>
+                <th>Diff WHS</th>
             </tr>
         </thead>
         <tbody>
@@ -34,9 +45,12 @@
                 <td>{{ c.golf.name if c.golf }}</td>
                 <td>{{ c.total_score }}</td>
                 <td>{{ c.total_sba }}</td>
+                <td>
+                    {% if c.diff is not none %}{{ c.diff }}{{ c.emoji }}{% endif %}
+                </td>
             </tr>
         {% else %}
-            <tr><td colspan="5">Aucune carte enregistrée.</td></tr>
+            <tr><td colspan="6">Aucune carte enregistrée.</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/templates/start_score.html
+++ b/templates/start_score.html
@@ -29,6 +29,7 @@
             </select>
             <a href="/golf">+</a>
         </label><br>
+        <label>PCC <input type="number" name="pcc" step="0.1" value="0" required></label><br>
         <button type="submit">Commencer la Saisie du Score</button>
     </form>
 </main>


### PR DESCRIPTION
## Summary
- support PCC adjustment when calculating WHS differentials
- store PCC when creating tours or starting new score entry
- show differential and optional emoji on score history page
- include differential on score summary page
- document new features in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68540f79114c8332b37520a4721fded1