### PR TITLE
Add PCC management

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,11 @@ scores_table = db.table('scores')
 stats_table = db.table('stats')
 golfs_table = db.table('golfs')
 
+# Ensure existing tours have a PCC value for backward compatibility
+for t in tours_table.all():
+    if 'pcc' not in t:
+        tours_table.update({'pcc': 0}, doc_ids=[t.doc_id])
+
 
 def distribute_handicap(handicap, hcps):
     """Return a list with strokes received for each hole."""
@@ -120,7 +125,9 @@ def start_score():
         name = request.form.get('name')
         jour = request.form.get('jour', type=int)
         date = request.form.get('date')
-        pcc = request.form.get('pcc', type=float)
+        pcc = request.form.get('pcc', type=int)
+        if pcc is None:
+            pcc = 0
         golf = golfs_table.get(doc_id=golf_id)
         if golf:
             pars = golf.get('pars', [4] * 18)
@@ -189,6 +196,9 @@ def add_tour():
         form_id = request.form.get('id', type=int)
         pars = [request.form.get(f'par_{i}', type=int) for i in range(1, 19)]
         hcps = [request.form.get(f'hcp_{i}', type=int) for i in range(1, 19)]
+        pcc_val = request.form.get('pcc', type=int)
+        if pcc_val is None:
+            pcc_val = 0
         tour = {
             'name': request.form.get('name'),
             'jour': request.form.get('jour', type=int),
@@ -197,7 +207,7 @@ def add_tour():
             'par': request.form.get('par', type=int),
             'slope': request.form.get('slope', type=int),
             'sss': request.form.get('sss', type=float),
-            'pcc': request.form.get('pcc', type=float),
+            'pcc': pcc_val,
             'pars': pars,
             'hcps': hcps,
         }

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -35,7 +35,9 @@
         <label>Par du parcours <input type="number" name="par" step="1" value="{{ tour.par if tour else '' }}" required></label><br>
         <label>Slope <input type="number" name="slope" step="1" value="{{ tour.slope if tour else '' }}" required></label><br>
         <label>SSS <input type="number" name="sss" step="0.1" value="{{ tour.sss if tour else '' }}" required></label><br>
-        <label>PCC <input type="number" name="pcc" step="0.1" value="{{ tour.pcc if tour else 0 }}" required></label><br>
+        <label><span title="Ajustement des conditions de jeu automatique calculé par la FFGolf, valeur entre -1 et +3.">PCC</span>
+            <input type="number" name="pcc" step="1" min="-1" max="3" value="{{ tour.pcc if tour else 0 }}" required>
+        </label><br>
         <h2>Par et HCP par trou</h2>
         <table>
             <thead>

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
                 <th>Nom</th>
                 <th>Jour</th>
                 <th>Date</th>
+                <th><span title="Ajustement des conditions de jeu automatique calculé par la FFGolf, valeur entre -1 et +3.">PCC</span></th>
                 <th>Golf</th>
                 <th>Total Score</th>
                 <th>Total SBA</th>
@@ -36,6 +37,7 @@
                 <td>{{ tour.name }}</td>
                 <td>{{ tour.get('jour') }}</td>
                 <td>{{ tour.get('date') }}</td>
+                <td>{{ tour.get('pcc', 0) }}</td>
                 <td>
                     {% set g = golfs.get(tour.golf_id) %}
                     {{ g.name if g }}
@@ -52,7 +54,7 @@
                 </td>
             </tr>
             {% else %}
-            <tr><td colspan="8">Aucun tour enregistré.</td></tr>
+            <tr><td colspan="9">Aucun tour enregistré.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/templates/scores_list.html
+++ b/templates/scores_list.html
@@ -31,6 +31,7 @@
             <tr>
                 <th>Nom</th>
                 <th>Jour</th>
+                <th><span title="Ajustement des conditions de jeu automatique calculé par la FFGolf, valeur entre -1 et +3.">PCC</span></th>
                 <th>Golf</th>
                 <th>Total Score</th>
                 <th>Total SBA</th>
@@ -42,6 +43,7 @@
             <tr>
                 <td>{{ c.tour.name }}</td>
                 <td>{{ c.tour.get('jour') }}</td>
+                <td>{{ c.tour.get('pcc', 0) }}</td>
                 <td>{{ c.golf.name if c.golf }}</td>
                 <td>{{ c.total_score }}</td>
                 <td>{{ c.total_sba }}</td>
@@ -50,7 +52,7 @@
                 </td>
             </tr>
         {% else %}
-            <tr><td colspan="6">Aucune carte enregistrée.</td></tr>
+            <tr><td colspan="7">Aucune carte enregistrée.</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/templates/start_score.html
+++ b/templates/start_score.html
@@ -29,7 +29,9 @@
             </select>
             <a href="/golf">+</a>
         </label><br>
-        <label>PCC <input type="number" name="pcc" step="0.1" value="0" required></label><br>
+        <label><span title="Ajustement des conditions de jeu automatique calculé par la FFGolf, valeur entre -1 et +3.">PCC</span>
+            <input type="number" name="pcc" step="1" min="-1" max="3" value="0" required>
+        </label><br>
         <button type="submit">Commencer la Saisie du Score</button>
     </form>
 </main>


### PR DESCRIPTION
## Summary
- add migration step ensuring PCC field exists
- parse PCC as integer with default value
- show PCC in list views and forms with tooltip
- limit PCC input range

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6854139760f48332a9df3d706e9da5f1