### PR TITLE
Add PCC update capability when entering scores

### DIFF
--- a/app.py
+++ b/app.py
@@ -250,6 +250,13 @@ def add_score(tour_id):
     Score = Query()
     existing_score = scores_table.get(Score.tour_id == tour_id)
     if request.method == 'POST':
+        # Allow updating the PCC value when submitting the score form
+        pcc_val = request.form.get('pcc', type=int)
+        if pcc_val is None:
+            pcc_val = 0
+        tours_table.update({'pcc': pcc_val}, doc_ids=[tour_id])
+        tour['pcc'] = pcc_val
+
         handicap = request.form.get('handicap', type=int)
         hcps = tour.get('hcps', list(range(1, 19)))
         given_dist = distribute_handicap(handicap, hcps)

--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -18,6 +18,9 @@
     <h1>Saisir Score pour {{ tour.name }}</h1>
     <form method="post">
         <label>Handicap de jeu <input type="number" name="handicap" id="handicap" value="{{ score.handicap if score else '' }}" required></label><br>
+        <label><span title="Ajustement des conditions de jeu automatique calculé par la FFGolf, valeur entre -1 et +3.">PCC</span>
+            <input type="number" name="pcc" step="1" min="-1" max="3" value="{{ tour.get('pcc', 0) }}" required>
+        </label><br>
         {% if score %}
         <input type="hidden" name="id" value="{{ score.doc_id }}">
         {% endif %}


### PR DESCRIPTION
## Summary
- allow editing the PCC value directly from the score entry form
- persist the updated PCC in the database when submitting scores

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68541515907c833293bf9977dccbf68c