### PR TITLE
Number last 20 golf rounds

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,10 @@ def index():
     tours = []
     # Sort tours by date descending so the most recent competition
     # appears first on the main page
-    for t in sorted(tours_table.all(), key=lambda x: x.get('date', ''), reverse=True):
+    for idx, t in enumerate(
+        sorted(tours_table.all(), key=lambda x: x.get('date', ''), reverse=True),
+        start=1,
+    ):
         score_entry = scores.get(t.doc_id)
         total_score = None
         total_sba = None
@@ -121,10 +124,16 @@ def index():
         tour_data = dict(t)
         tour_data['doc_id'] = t.doc_id
         tour_data['total_score'] = total_score
-        tour_data['total_sba'] = formatted_sba if formatted_sba is not None else None
+        tour_data['total_sba'] = (
+            formatted_sba if formatted_sba is not None else None
+        )
         tour_data['diff_whs'] = diff_whs_val
         tour_data['highlight_diff'] = t.doc_id in best_diff_ids
         tour_data['has_score'] = score_entry is not None
+        if idx <= 20:
+            tour_data['recent_no'] = idx
+        else:
+            tour_data['recent_no'] = None
         tours.append(tour_data)
     return render_template('index.html', tours=tours, golfs=golfs, new_index=new_index)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
 <table class="table table-bordered table-striped">
     <thead>
         <tr>
+            <th>N°</th>
             <th>Nom</th>
             <th>Jour</th>
             <th>Date</th>
@@ -22,6 +23,7 @@
     <tbody>
         {% for tour in tours %}
         <tr>
+            <td>{{ tour.recent_no if tour.recent_no is not none else '' }}</td>
             <td>{{ tour.name }}</td>
             <td>{{ tour.get('jour') }}</td>
             <td>{{ tour.get('date') }}</td>
@@ -42,7 +44,7 @@
             </td>
         </tr>
         {% else %}
-        <tr><td colspan="9">Aucun tour enregistré.</td></tr>
+        <tr><td colspan="10">Aucun tour enregistré.</td></tr>
         {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- enumerate tours on the home page
- display numbering for the 20 most recent rounds

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68582624f72c833281c21ad859bbb0c4