### PR TITLE
Make SBA editable after saving score

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Key features:
 - Full CRUD management for tours with per-hole par values, a day number and a date.
 - Manage golf courses (name, course, par, slope, SSS and per-hole pars).
 - Input scores for each hole of a tour.
+- After saving a scorecard, the automatically computed SBA values can be edited.
 - PCC can be stored for each round to adjust the WHS differential.
 - Quick creation of a tour using "Nouvelle Carte" to jump directly to score entry.
 - View, edit and delete existing tours from the home page.

--- a/app.py
+++ b/app.py
@@ -286,7 +286,11 @@ def add_score(tour_id):
             strokes = request.form.get(f'strokes_{i}', type=int)
             given = given_dist[i-1]
             limit = par + 2 + given
-            adjusted = min(strokes, limit) if strokes is not None else None
+            adjusted_from_form = request.form.get(f'adjusted_{i}', type=int)
+            if adjusted_from_form is not None and existing_score:
+                adjusted = adjusted_from_form
+            else:
+                adjusted = min(strokes, limit) if strokes is not None else None
             hole = {
                 'par': par,
                 'strokes_given': given,

--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -53,7 +53,7 @@
             <tr>
                 <th>Score brut ajusté</th>
                 {% for i in range(1, 19) %}
-                <td><input type="number" name="adjusted_{{ i }}" id="adjusted_{{ i }}" value="{{ score.holes[i-1].adjusted if score else '' }}" class="form-control" readonly></td>
+                <td><input type="number" name="adjusted_{{ i }}" id="adjusted_{{ i }}" value="{{ score.holes[i-1].adjusted if score else '' }}" class="form-control" {% if not score %}readonly{% endif %}></td>
                 {% endfor %}
             </tr>
             <tr>


### PR DESCRIPTION
## Summary
- allow editing SBA values after saving a card
- store user-provided SBA values when a card already exists
- document ability to edit SBA values

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68582a789b4c83329a4a1d3357e0c18f