### PR TITLE
Hide CSRF tokens

### DIFF
--- a/templates/add_score.html
+++ b/templates/add_score.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="mb-3">Saisir Score pour {{ tour.name }}</h1>
 <form method="post">
-    {{ csrf_token() }}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="mb-3">
         <label class="form-label">Handicap de jeu
             <input type="number" name="handicap" id="handicap" value="{{ score.handicap if score else '' }}" class="form-control" required>

--- a/templates/add_tour.html
+++ b/templates/add_tour.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h1 class="mb-3">{{ page_title }}</h1>
 <form method="post">
-    {{ csrf_token() }}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% if tour %}
     <input type="hidden" name="id" value="{{ tour.doc_id }}">
     {% endif %}

--- a/templates/golf_form.html
+++ b/templates/golf_form.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h1 class="mb-3">{{ page_title }}</h1>
 <form method="post">
-    {{ csrf_token() }}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% if golf %}
     <input type="hidden" name="id" value="{{ golf.doc_id }}">
     {% endif %}
@@ -86,7 +86,7 @@
             <td>
                 <a class="btn btn-sm btn-secondary" href="{{ url_for('manage_golf', id=g.doc_id) }}">Modifier</a>
                 <form action="{{ url_for('delete_golf', golf_id=g.doc_id) }}" method="post" class="d-inline">
-                    {{ csrf_token() }}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button class="btn btn-sm btn-danger" type="submit" onclick="return confirm('Supprimer ce golf ?');">Supprimer</button>
                 </form>
             </td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
             <td>
                 <a class="btn btn-sm btn-secondary" href="{{ url_for('add_tour', id=tour.doc_id) }}">Modifier</a>
                 <form action="{{ url_for('delete_tour', tour_id=tour.doc_id) }}" method="post" class="d-inline">
-                    {{ csrf_token() }}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button class="btn btn-sm btn-danger" type="submit" onclick="return confirm('Supprimer ce tour ?');">Supprimer</button>
                 </form>
                 <a class="btn btn-sm btn-primary" href="{{ url_for('add_score', tour_id=tour.doc_id) }}">{% if tour.has_score %}Voir Carte{% else %}Ajouter Carte{% endif %}</a>

--- a/templates/start_score.html
+++ b/templates/start_score.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="mb-3">Nouvelle Carte</h1>
 <form method="post">
-    {{ csrf_token() }}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="mb-3">
         <label class="form-label">Nom du Tour
             <input type="text" name="name" class="form-control" required>


### PR DESCRIPTION
## Summary
- wrap CSRF token values in hidden inputs so they are no longer visible

## Testing
- `python -m py_compile app.py forms.py models.py config.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685969f1f4688332a8b318404fcf7e1e