### PR TITLE
Improve day theme readability

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2,8 +2,17 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Segoe UI', Roboto, sans-serif;
-  background: linear-gradient(45deg, #2c3e50, #4ca1af);
   min-height: 100vh;
+}
+
+body.dark-theme {
+  background: linear-gradient(45deg, #2c3e50, #4ca1af);
+  color: #fff;
+}
+
+body.light-theme {
+  background: #f8f9fa;
+  color: #212529;
 }
 .best-diff {
   color: #ffae42;

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
 {% if new_index is not none %}
 <p class="text-center fw-bold">Nouvel Index: {{ new_index }}</p>
 {% endif %}
+<div class="table-responsive">
 <table class="table table-bordered table-striped">
     <thead>
         <tr>
@@ -49,4 +50,5 @@
         {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 </head>
-<body>
+<body class="dark-theme">
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('index') }}">WHS Golf</a>
@@ -41,10 +41,19 @@
 <script>
   function setTheme(theme){
     const link = document.getElementById('theme-link');
+    const icon = document.querySelector('.theme-toggle i');
     if(theme === 'light'){
       link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/lux/bootstrap.min.css';
+      document.body.classList.remove('dark-theme');
+      document.body.classList.add('light-theme');
+      icon.classList.remove('bi-moon-fill');
+      icon.classList.add('bi-moon');
     }else{
       link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css';
+      document.body.classList.remove('light-theme');
+      document.body.classList.add('dark-theme');
+      icon.classList.remove('bi-moon');
+      icon.classList.add('bi-moon-fill');
     }
     localStorage.setItem('theme', theme);
   }
@@ -56,10 +65,8 @@
   }
 
   document.addEventListener('DOMContentLoaded', function(){
-    const saved = localStorage.getItem('theme');
-    if(saved && saved !== 'dark'){
-      setTheme(saved);
-    }
+    const saved = localStorage.getItem('theme') || 'dark';
+    setTheme(saved);
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- tweak CSS to define light/dark backgrounds
- add theme classes to body and update toggle script
- make the main table responsive

## Testing
- `python -m py_compile app.py forms.py models.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_68596c065ae08332a6c0b7689686c66e