### PR TITLE
Change light theme font to Inter

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -13,6 +13,7 @@ body.dark-theme {
 body.light-theme {
   background: #f8f9fa;
   color: #212529;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
 }
 .best-diff {
   color: #ffae42;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -6,6 +6,7 @@
     <link id="theme-link" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap">
 </head>
 <body class="dark-theme">
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">


### PR DESCRIPTION
## Summary
- import the Inter webfont in layout.html
- use Inter in light mode styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596d5d65e8833295529dcc0c4f76bb