### PR TITLE
Improve dark theme readability

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -6,8 +6,9 @@ body {
 }
 
 body.dark-theme {
-  background: linear-gradient(45deg, #2c3e50, #4ca1af);
+  background: #212529;
   color: #fff;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
 }
 
 body.light-theme {


### PR DESCRIPTION
## Summary
- tweak dark theme styles to increase contrast

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68596dffe7c88332b77ec84380fc51c0