### PR TITLE
Fix score page fields

### DIFF
--- a/models.py
+++ b/models.py
@@ -9,6 +9,11 @@ class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
 
+    @property
+    def doc_id(self):
+        """Return id for compatibility with templates expecting doc_id."""
+        return self.id
+
 
 class Golf(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -20,6 +25,11 @@ class Golf(db.Model):
     tees = db.Column(db.String(20))
     pars = db.Column(db.PickleType)
     hcps = db.Column(db.PickleType)
+
+    @property
+    def doc_id(self):
+        """Return id for compatibility with templates expecting doc_id."""
+        return self.id
 
 
 class Tour(db.Model):
@@ -39,6 +49,11 @@ class Tour(db.Model):
     golf = db.relationship('Golf')
     user = db.relationship('User')
 
+    @property
+    def doc_id(self):
+        """Return id for compatibility with templates expecting doc_id."""
+        return self.id
+
 
 class Score(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -47,6 +62,11 @@ class Score(db.Model):
     holes = db.Column(db.PickleType)
 
     tour = db.relationship('Tour')
+
+    @property
+    def doc_id(self):
+        """Return id for compatibility with templates expecting doc_id."""
+        return self.id
 
 
 class Stats(db.Model):

--- a/static/styles.css
+++ b/static/styles.css
@@ -27,3 +27,8 @@ body.light-theme {
   right: 1rem;
   z-index: 1000;
 }
+
+/* Ensure score inputs are wide enough for multi-digit values */
+td input[type="number"].form-control {
+  min-width: 3.5ch;
+}


### PR DESCRIPTION
## Summary
- expose `doc_id` property on ORM models so templates get proper IDs
- enlarge numeric inputs to display multi-digit values

## Testing
- `python -m py_compile app.py models.py forms.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_68596f28e94c8332a4f53a5c9b65c20e