### PR TITLE
Add TailwindCSS theme with dark mode support

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,20 +1,18 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
   min-height: 100vh;
 }
 
-body.dark-theme {
-  background: #212529;
-  color: #fff;
-  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+body.light-theme {
+  background: #F5F5F5;
+  color: #333333;
 }
 
-body.light-theme {
-  background: #f8f9fa;
-  color: #212529;
-  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+body.dark-theme {
+  background: #121212;
+  color: #E0E0E0;
 }
 .best-diff {
   color: #ffae42;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  darkMode: 'class', // ← Active le mode dark via .dark dans HTML
+  theme: {
+    extend: {
+      colors: {
+        golf: {
+          green: '#2E7D32',
+          darkgreen: '#1B5E20',
+          beige: '#D7C4A3',
+          gold: '#C19A6B',
+          ocean: '#0277BD',
+          rust: '#B71C1C',
+          background: '#F5F5F5',
+          darkbg: '#121212',
+          text: '#333333',
+          darktext: '#E0E0E0',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,8 +7,36 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            colors: {
+              golf: {
+                green: '#2E7D32',
+                darkgreen: '#1B5E20',
+                beige: '#D7C4A3',
+                gold: '#C19A6B',
+                ocean: '#0277BD',
+                rust: '#B71C1C',
+                background: '#F5F5F5',
+                darkbg: '#121212',
+                text: '#333333',
+                darktext: '#E0E0E0',
+              },
+            },
+            fontFamily: {
+              sans: ['Inter', 'sans-serif'],
+            },
+          },
+        },
+        plugins: [],
+      }
+    </script>
 </head>
-<body class="dark-theme">
+<body class="dark-theme dark">
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('index') }}">WHS Golf</a>
@@ -45,14 +73,14 @@
     const icon = document.querySelector('.theme-toggle i');
     if(theme === 'light'){
       link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/lux/bootstrap.min.css';
-      document.body.classList.remove('dark-theme');
+      document.body.classList.remove('dark-theme', 'dark');
       document.body.classList.add('light-theme');
       icon.classList.remove('bi-moon-fill');
       icon.classList.add('bi-moon');
     }else{
       link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css';
       document.body.classList.remove('light-theme');
-      document.body.classList.add('dark-theme');
+      document.body.classList.add('dark-theme', 'dark');
       icon.classList.remove('bi-moon');
       icon.classList.add('bi-moon-fill');
     }


### PR DESCRIPTION
## Summary
- integrate TailwindCSS via CDN with a custom theme
- support dark mode using Tailwind's `dark` class
- refine light/dark theme styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685971709a5c8332a03c8cbe69e7665c