### PR TITLE
Fix table layout consistency across themes

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -97,22 +97,28 @@ a:hover {
 .badge-gold  { background-color: var(--golf-gold);  color: white; padding: 0.25em 0.6em; border-radius: 6px; }
 
 /* Tableau */
-table {
+table,
+.table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
   margin-top: 1rem;
 }
-th, td {
-  padding: 0.75rem 1rem;
+th, td,
+.table th,
+.table td {
+  padding: 0.75rem 1rem !important;
   border-bottom: 1px solid #ccc;
 }
-th {
+th,
+.table th {
   background-color: var(--golf-beige);
   color: var(--golf-text);
 }
 
 /* Dark mode override */
-.dark table th {
+.dark table th,
+.dark .table th {
   background-color: #2c2c2c;
   color: var(--golf-text);
 }


### PR DESCRIPTION
## Summary
- enforce a fixed layout for tables via CSS
- align table cell padding across all themes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597d1f6cec8332b898278fdac4c08b