### PR TITLE
Add score card view

### DIFF
--- a/app.py
+++ b/app.py
@@ -378,6 +378,25 @@ def list_scores():
     return render_template('scores_list.html', cards=cards, current_index=current_index, sort=sort_key)
 
 
+@app.route('/view_score/<int:tour_id>')
+@login_required
+def view_score(tour_id):
+    tour = db.session.get(Tour, tour_id)
+    score = Score.query.filter_by(tour_id=tour_id).first()
+    stats = Stats.query.filter_by(tour_id=tour_id).first()
+    if not tour or not score:
+        return redirect(url_for('index'))
+    diff_val = None
+    if tour.slope and tour.sss is not None:
+        diff_val = diff_whs(
+            sum(h.get('adjusted') or 0 for h in score.holes or []),
+            tour.slope,
+            tour.sss,
+            tour.pcc,
+        )
+    return render_template('view_score.html', tour=tour, score=score, stats=stats, diff=diff_val)
+
+
 @app.route('/export/csv')
 @login_required
 def export_csv():

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,12 @@
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button class="btn btn-sm btn-danger" type="submit" onclick="return confirm('Supprimer ce tour ?');">Supprimer</button>
                 </form>
-                <a class="btn btn-sm btn-primary" href="{{ url_for('add_score', tour_id=tour.doc_id) }}">{% if tour.has_score %}Voir Carte{% else %}Ajouter Carte{% endif %}</a>
+                {% if tour.has_score %}
+                <a class="btn btn-sm btn-primary" href="{{ url_for('view_score', tour_id=tour.doc_id) }}">Voir Carte</a>
+                <a class="btn btn-sm btn-secondary" href="{{ url_for('add_score', tour_id=tour.doc_id) }}">Éditer Carte</a>
+                {% else %}
+                <a class="btn btn-sm btn-primary" href="{{ url_for('add_score', tour_id=tour.doc_id) }}">Ajouter Carte</a>
+                {% endif %}
             </td>
         </tr>
         {% else %}

--- a/templates/scores_list.html
+++ b/templates/scores_list.html
@@ -35,7 +35,7 @@
     <tbody>
     {% for c in cards %}
         <tr>
-            <td>{{ c.tour.name }}</td>
+            <td><a href="{{ url_for('view_score', tour_id=c.tour.id) }}">{{ c.tour.name }}</a></td>
             <td>{{ c.tour.jour }}</td>
             <td>{{ c.tour.pcc if c.tour.pcc is not none else 0 }}</td>
             <td>{{ c.golf.name if c.golf }}</td>

--- a/templates/view_score.html
+++ b/templates/view_score.html
@@ -1,0 +1,86 @@
+{% extends 'layout.html' %}
+{% block title %}Carte de Score{% endblock %}
+{% block content %}
+<h1 class="mb-3">Carte de Score - {{ tour.name }}</h1>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th></th>
+            {% for i in range(1, 19) %}
+            <th>{{ i }}</th>
+            {% endfor %}
+            <th>Total</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>Par</th>
+            {% set total_par = 0 %}
+            {% for h in score.holes %}
+            {% set total_par = total_par + (h.par or 0) %}
+            <td>{{ h.par }}</td>
+            {% endfor %}
+            <td>{{ total_par }}</td>
+        </tr>
+        <tr>
+            <th>HCP</th>
+            {% for h in tour.hcps %}
+            <td>{{ h }}</td>
+            {% endfor %}
+            <td></td>
+        </tr>
+        <tr>
+            <th>Coups reçus</th>
+            {% for h in score.holes %}
+            <td>{{ h.strokes_given }}</td>
+            {% endfor %}
+            <td>{{ score.handicap }}</td>
+        </tr>
+        <tr>
+            <th>Score</th>
+            {% set total_score = 0 %}
+            {% for h in score.holes %}
+            {% set total_score = total_score + (h.strokes or 0) %}
+            <td>{{ h.strokes }}</td>
+            {% endfor %}
+            <td>{{ total_score }}</td>
+        </tr>
+        <tr>
+            <th>Score brut ajusté</th>
+            {% set total_sba = 0 %}
+            {% for h in score.holes %}
+            {% set total_sba = total_sba + (h.adjusted or 0) %}
+            <td>{{ h.adjusted }}</td>
+            {% endfor %}
+            <td>{{ total_sba }}</td>
+        </tr>
+        <tr>
+            <th>Fairway touché</th>
+            {% for h in score.holes %}
+            <td class="text-center">{% if h.fairway %}✓{% endif %}</td>
+            {% endfor %}
+            <td>{% if stats %}{{ stats.fairway_hits }}/{{ stats.fairway_possible }}{% endif %}</td>
+        </tr>
+        <tr>
+            <th>Green en régulation</th>
+            {% for h in score.holes %}
+            <td class="text-center">{% if h.gir %}✓{% endif %}</td>
+            {% endfor %}
+            <td>{% if stats %}{{ stats.gir_hits }}/18{% endif %}</td>
+        </tr>
+        <tr>
+            <th>Nb de Putts</th>
+            {% set total_putts = 0 %}
+            {% for h in score.holes %}
+            {% set total_putts = total_putts + (h.putts or 0) %}
+            <td>{{ h.putts }}</td>
+            {% endfor %}
+            <td>{{ total_putts }}</td>
+        </tr>
+    </tbody>
+</table>
+{% if diff is not none %}
+<p>Différentiel WHS : {{ diff }}</p>
+{% endif %}
+<a href="{{ url_for('index') }}" class="btn btn-secondary mt-3">Retour</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- display detailed scorecard in a new page
- link score list and home page to the new view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685982db8e6883329700182383532b88