### PR TITLE
Remove spinner arrows for score inputs

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -180,3 +180,13 @@ td input[type="number"].form-control {
   color: #ffae42;
   font-weight: bold;
 }
+
+/* Remove spinner arrows from number inputs for cleaner score editing */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type="number"] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## Summary
- hide number input spinners so score fields look like plain text boxes

## Testing
- `python -m py_compile app.py forms.py models.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_685a43de0d60833290d6125de5b4a4fa