### PR TITLE
Unify golf theme styles with dark mode

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -65,7 +65,7 @@ a:hover {
 .button {
   padding: 0.5em 1em;
   border: none;
-  border-radius: 8px;
+  border-radius: 0.375rem;
   font-weight: 600;
   cursor: pointer;
   background-color: var(--accent-color);
@@ -79,7 +79,7 @@ a:hover {
 /* Cartes */
 .card {
   background-color: white;
-  border-radius: 12px;
+  border-radius: 0.375rem;
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
   padding: 1.5rem;
   margin: 1rem 0;
@@ -189,4 +189,19 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 input[type="number"] {
   -moz-appearance: textfield;
+}
+
+/* Harmonise le theme golf avec les dimensions du mode sombre */
+.golf-theme,
+.dark-theme {
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+}
+
+.golf-theme .form-control,
+.golf-theme .form-select,
+.golf-theme .btn,
+.golf-theme .card {
+  border-radius: 0.375rem;
+  font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- tweak custom button and card styles to use same rounding as dark theme
- align the golf theme font family, font size and component rounding with dark theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a45b0a66483328f81fa553e51f11f