### PR TITLE
Apply golf theme typography to dark mode

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -196,12 +196,17 @@ input[type="number"] {
 .dark-theme {
   font-family: 'Inter', sans-serif;
   font-size: 1rem;
+  --bs-body-font-family: 'Inter', sans-serif;
 }
 
 .golf-theme .form-control,
 .golf-theme .form-select,
 .golf-theme .btn,
-.golf-theme .card {
+.golf-theme .card,
+.dark-theme .form-control,
+.dark-theme .form-select,
+.dark-theme .btn,
+.dark-theme .card {
   border-radius: 0.375rem;
   font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- ensure dark theme uses Inter font and 1rem size
- apply same form-control and button font rules across themes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a470d9a588332a7e7d7915e926534