### PR TITLE
Fix golf theme input text color

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -210,3 +210,8 @@ input[type="number"] {
   border-radius: 0.375rem;
   font-size: 1rem;
 }
+
+/* Ensure table input text is clearly visible in golf theme */
+.golf-theme .form-control {
+  color: #000;
+}


### PR DESCRIPTION
## Summary
- ensure text inputs show up clearly in golf theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a48bda7208332a44578114e31d4ed