### PR TITLE
Improve score list filtering and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Key features:
 - Quick creation of a tour using "Nouvelle Carte" to jump directly to score entry.
 - View, edit and delete existing tours from the home page.
 - Statistics for each scorecard are stored in the SQLite database and the WHS differential is shown when viewing a card.
+- Filter the score list by golf course for easier navigation.
+- Harmonised typography and table layout for a smoother user experience.
 
 Install dependencies with:
 ```

--- a/app.py
+++ b/app.py
@@ -342,12 +342,15 @@ def add_score(tour_id):
 def list_scores():
     current_index = request.args.get('index', type=float)
     sort_key = request.args.get('sort', 'date')
+    golf_filter = request.args.get('golf', type=int)
     golfs = {g.id: g for g in Golf.query.all()}
     tours = {t.id: t for t in Tour.query.all()}
     cards = []
     for s in Score.query.all():
         tour = tours.get(s.tour_id)
         if not tour:
+            continue
+        if golf_filter and tour.golf_id != golf_filter:
             continue
         holes = s.holes or []
         total_score = sum(h.get('strokes', 0) for h in holes)
@@ -375,7 +378,14 @@ def list_scores():
         cards.sort(key=lambda x: (x['diff'] is None, x.get('diff')))
     else:
         cards.sort(key=lambda x: x['tour'].date or '')
-    return render_template('scores_list.html', cards=cards, current_index=current_index, sort=sort_key)
+    return render_template(
+        'scores_list.html',
+        cards=cards,
+        current_index=current_index,
+        sort=sort_key,
+        golfs=golfs,
+        golf_filter=golf_filter,
+    )
 
 
 @app.route('/view_score/<int:tour_id>')

--- a/static/styles.css
+++ b/static/styles.css
@@ -27,6 +27,8 @@ body {
   font-family: 'Inter', sans-serif;
   background-color: var(--golf-bg);
   color: var(--golf-text);
+  font-size: 1rem;
+  line-height: 1.6;
   min-height: 100vh;
   transition: background-color 0.3s ease, color 0.3s ease;
   padding-top: 48px; /* offset for reduced navbar */
@@ -116,11 +118,13 @@ th, td,
 .table td {
   padding: 0.75rem 1rem !important;
   border-bottom: 1px solid #ccc;
+  font-size: 0.95rem;
 }
 th,
 .table th {
   background-color: var(--golf-beige);
   color: var(--golf-text);
+  font-weight: 600;
 }
 
 /* Dark mode override */
@@ -148,6 +152,10 @@ th,
 .p-2 { padding: 0.5rem; }
 .rounded { border-radius: 0.5rem; }
 .shadow { box-shadow: 0 2px 6px rgba(0,0,0,0.15); }
+
+.form-label {
+  font-size: 0.95rem;
+}
 
 /* Theme toggle button */
 .theme-toggle {
@@ -215,7 +223,7 @@ input[type="number"] {
 .dark-theme .btn,
 .dark-theme .card {
   border-radius: 0.375rem;
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 /* Ensure table input text is clearly visible in golf theme */

--- a/templates/scores_list.html
+++ b/templates/scores_list.html
@@ -16,6 +16,16 @@
             </select>
         </label>
     </div>
+    <div class="col-auto">
+        <label class="form-label">Golf
+            <select name="golf" class="form-select">
+                <option value="">Tous</option>
+                {% for g in golfs.values() %}
+                <option value="{{ g.id }}" {% if g.id == golf_filter %}selected{% endif %}>{{ g.name }}</option>
+                {% endfor %}
+            </select>
+        </label>
+    </div>
     <div class="col-auto align-self-end">
         <button type="submit" class="btn btn-primary">Appliquer</button>
     </div>


### PR DESCRIPTION
## Summary
- add filter by golf in score list
- tweak theme fonts and table styling
- document new capabilities in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c00d1eeb083328606f6bd10b7a309